### PR TITLE
Fix the query capturing issue of Atatus

### DIFF
--- a/db_multitenant/db/backends/mysql/base.py
+++ b/db_multitenant/db/backends/mysql/base.py
@@ -24,15 +24,15 @@ class CursorWrapper(WRAPPED_BACKEND.CursorWrapper):
         cid = get_cid()
         cid_sql_template = getattr(settings, "CID_SQL_COMMENT_TEMPLATE", "cid: {cid}")
         cid = cid.replace("/*", r"\/\*").replace("*/", r"\*\/")
-         return "{}\n/* {} */".format(sql, cid_sql_template.format(cid=cid))
+        return "{}\n/* {} */".format(sql, cid_sql_template.format(cid=cid))
 
     def execute(self, query, args=None):
-        query = super().execute(query, args)
-        return self._add_comment(query)
+        query = self._add_comment(query)
+        return super().execute(query, args)
 
     def executemany(self, query, args):
-        query = super().executemany(query, args)
-        return self._add_comment(query)
+        query = self._add_comment(query)
+        return super().executemany(query, args)
 
 
 class DatabaseWrapper(WRAPPED_BACKEND.DatabaseWrapper):

--- a/db_multitenant/db/backends/mysql/base.py
+++ b/db_multitenant/db/backends/mysql/base.py
@@ -24,7 +24,7 @@ class CursorWrapper(WRAPPED_BACKEND.CursorWrapper):
         cid = get_cid()
         cid_sql_template = getattr(settings, "CID_SQL_COMMENT_TEMPLATE", "cid: {cid}")
         cid = cid.replace("/*", r"\/\*").replace("*/", r"\*\/")
-        return "/* {} */\n{}".format(cid_sql_template.format(cid=cid), sql)
+         return "{}\n/* {} */".format(sql, cid_sql_template.format(cid=cid))
 
     def execute(self, query, args=None):
         query = super().execute(query, args)

--- a/db_multitenant/db/backends/mysql/base.py
+++ b/db_multitenant/db/backends/mysql/base.py
@@ -27,12 +27,12 @@ class CursorWrapper(WRAPPED_BACKEND.CursorWrapper):
         return "/* {} */\n{}".format(cid_sql_template.format(cid=cid), sql)
 
     def execute(self, query, args=None):
-        query = self._add_comment(query)
-        return super().execute(query, args)
+        query = super().execute(query, args)
+        return self._add_comment(query)
 
     def executemany(self, query, args):
-        query = self._add_comment(query)
-        return super().executemany(query, args)
+        query = super().executemany(query, args)
+        return self._add_comment(query)
 
 
 class DatabaseWrapper(WRAPPED_BACKEND.DatabaseWrapper):


### PR DESCRIPTION
Move add_comment() call to the end of query running function to fix the query capturing issue of Atatus Library.